### PR TITLE
trim trailing witespaces in now default in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 charset = utf-8
 
 [*.{js,json,html,scss,less}]


### PR DESCRIPTION
This change strengtheneth overall developer experience in IDE, since .eslint also requires whitespace trimming.