### PR TITLE
Update eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,7 @@
   "env": {
     "browser": true,
     "node": true,
+    "mocha": true,
     "es6": true
   },
   "parserOptions": {
@@ -105,8 +106,6 @@
     "no-div-regex": "off",
     // disallow else after a return in an if
     "no-else-return": "off",
-    // disallow empty functions
-    "no-empty-function": "error",
     // disallow use of empty destructuring patterns
     "no-empty-pattern": "error",
     // disallow comparisons to null without a type-checking operator
@@ -460,7 +459,7 @@
     // enforce spacing between rest and spread operators and their expressions
     "rest-spread-spacing": ["error", "never"],
     // enforce sorted import declarations within modules
-    "sort-imports": "error",
+    "sort-imports": "off",
     // require or disallow spacing around embedded expressions of template strings
     "template-curly-spacing": ["error", "never"],
     // require or disallow spacing around the * in yield* expressions

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,8 +2,8 @@
   "env": {
     "browser": true,
     "node": true,
-    "mocha": true,
-    "es6": true
+    "es6": true,
+    "mocha": true
   },
   "parserOptions": {
     "sourceType": "module",
@@ -85,7 +85,7 @@
     // require return statements to either always or never specify values
     "consistent-return": "off",
     // specify curly brace conventions for all control statements
-    "curly": [2, "all"],
+    "curly": ["error", "all"],
     // require default case in switch statements
     "default-case": "error",
     // enforces consistent newlines before or after dots
@@ -106,6 +106,8 @@
     "no-div-regex": "off",
     // disallow else after a return in an if
     "no-else-return": "off",
+    // disallow empty functions
+    "no-empty-function": "error",
     // disallow use of empty destructuring patterns
     "no-empty-pattern": "error",
     // disallow comparisons to null without a type-checking operator
@@ -299,7 +301,7 @@
     // specify the maximum depth that blocks can be nested
     "max-depth": "off",
     // specify the maximum length of a line in your program
-    "max-len": [2, 120],
+    "max-len": ["error", 120],
     // enforce a maximum number of lines per file
     "max-lines": "off",
     // specify the maximum depth callbacks can be nested
@@ -459,7 +461,7 @@
     // enforce spacing between rest and spread operators and their expressions
     "rest-spread-spacing": ["error", "never"],
     // enforce sorted import declarations within modules
-    "sort-imports": "off",
+    "sort-imports": "error",
     // require or disallow spacing around embedded expressions of template strings
     "template-curly-spacing": ["error", "never"],
     // require or disallow spacing around the * in yield* expressions

--- a/.eslintrc
+++ b/.eslintrc
@@ -12,8 +12,71 @@
     }
   },
   "rules": {
+    // POSSIBLE ERRORS
+    // disallow assignment in conditional expressions
+    "no-cond-assign": "error",
+    // disallow use of console
+    "no-console": "error",
+    // disallow use of constant expressions in conditions
+    "no-constant-condition": "error",
+    // disallow control characters in regular expressions
+    "no-control-regex": "error",
+    // disallow use of debugger
+    "no-debugger": "error",
+    // disallow duplicate arguments in functions
+    "no-dupe-args": "error",
+    // disallow duplicate keys when creating object literals
+    "no-dupe-keys": "error",
+    // disallow a duplicate case label.
+    "no-duplicate-case": "error",
+    // disallow the use of empty character classes in regular expressions
+    "no-empty-character-class": "error",
+    // disallow empty statements
+    "no-empty": "error",
+    // disallow assigning to the exception in a catch block
+    "no-ex-assign": "error",
+    // disallow double-negation boolean casts in a boolean context
+    "no-extra-boolean-cast": "error",
+    // disallow unnecessary parentheses
+    "no-extra-parens": "error",
+    // disallow unnecessary semicolons
+    "no-extra-semi": "error",
+    // disallow overwriting functions written as function declarations
+    "no-func-assign": "error",
+    // disallow function or variable declarations in nested blocks
+    "no-inner-declarations": "error",
+    // disallow invalid regular expression strings in the RegExp constructor
+    "no-invalid-regexp": "error",
+    // disallow irregular whitespace outside of strings and comments
+    "no-irregular-whitespace": "error",
+    // disallow negation of the left operand of an in expression
+    "no-negated-in-lhs": "error",
+    // disallow the use of object properties of the global object (Math and JSON) as functions
+    "no-obj-calls": "error",
+    // disallow use of Object.prototypes builtins directly
+    "no-prototype-builtins": "error",
+    // disallow multiple spaces in a regular expression literal
+    "no-regex-spaces": "error",
+    // disallow sparse arrays
+    "no-sparse-arrays": "error",
+    // Avoid code that looks like two expressions but is actually one
+    "no-unexpected-multiline": "error",
+    // disallow unreachable statements after a return, throw, continue, or break statement
+    "no-unreachable": "error",
+    // disallow control flow statements in finally blocks
+    "no-unsafe-finally": "error",
+    // disallow comparisons with the value NaN
+    "use-isnan": "error",
+    // ensure JSDoc comments are valid
+    "valid-jsdoc": "error",
+    // ensure that the results of typeof are compared against a valid string
+    "valid-typeof": "error",
+
+    // BEST PRACTIES
     // Enforces getter/setter pairs in objects
     "accessor-pairs": "off",
+    // Enforces return statements in callbacks of array methods
+    "array-callback-return": "error",
     // treat var statements as if they were block scoped
     "block-scoped-var": "off",
     // specify the maximum cyclomatic complexity allowed in a program
@@ -42,12 +105,10 @@
     "no-div-regex": "off",
     // disallow else after a return in an if
     "no-else-return": "off",
+    // disallow empty functions
+    "no-empty-function": "error",
     // disallow use of empty destructuring patterns
     "no-empty-pattern": "error",
-    // disallow symbol constructor
-    "no-new-symbol": "error",
-    // disallow self assignment
-    "no-self-assign": "error",
     // disallow comparisons to null without a type-checking operator
     "no-eq-null": "off",
     // disallow use of eval()
@@ -56,12 +117,16 @@
     "no-extend-native": "error",
     // disallow unnecessary function binding
     "no-extra-bind": "off",
+    // disallow unnecessary labels
+    "no-extra-label": "error",
     // disallow fallthrough of case statements
-    "no-fallthrough": "off",
+    "no-fallthrough": "error",
     // disallow the use of leading or trailing decimal points in numeric literals
     "no-floating-decimal": "off",
     // disallow the type conversions with shorter notations
     "no-implicit-coercion": "off",
+    // disallow var and named function declarations in the global scope
+    "no-implicit-globals": "error",
     // disallow use of eval()-like methods
     "no-implied-eval": "off",
     // disallow this keywords outside of classes or class-like objects
@@ -81,42 +146,47 @@
     // disallow use of multiline strings
     "no-multi-str": "error",
     // disallow reassignments of native objects
-    "no-native-reassign": "off",
+    "no-native-reassign": "error",
     // disallow use of new operator for Function object
     "no-new-func": "off",
     // disallows creating new instances of String,Number, and Boolean
     "no-new-wrappers": "off",
     // disallow use of new operator when not part of the assignment or comparison
     "no-new": "off",
-    // disallow use of octal escape sequences in string literals, such as
-    // var foo = "Copyright \251";
+    // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
     "no-octal-escape": "off",
     // disallow use of (old style) octal literals
-    "no-octal": "off",
+    "no-octal": "error",
     // disallow reassignment of function parameters
     "no-param-reassign": "off",
-    // disallow use of process.env
-    "no-process-env": "off",
     // disallow usage of __proto__ property
     "no-proto": "off",
     // disallow declaring the same variable more then once
-    "no-redeclare": "off",
+    "no-redeclare": "error",
     // disallow use of assignment in return statement
     "no-return-assign": "off",
     // disallow use of `javascript:` urls.
     "no-script-url": "off",
+    // disallow assignments where both sides are exactly the same
+    "no-self-assign": "error",
     // disallow comparisons where both sides are exactly the same
     "no-self-compare": "off",
     // disallow use of comma operator
     "no-sequences": "off",
     // restrict what can be thrown as an exception
     "no-throw-literal": "off",
+    // disallow unmodified loop conditions
+    "no-unmodified-loop-condition": "off",
     // disallow usage of expressions in statement position
     "no-unused-expressions": "off",
+    // disallow unused labels
+    "no-unused-labels": "error",
     // disallow unnecessary .call() and .apply()
     "no-useless-call": "off",
     // disallow unnecessary concatenation of literals or template literals
     "no-useless-concat": "off",
+    // disallow unnecessary escape characters
+    "no-useless-escape": "error",
     // disallow use of void operator
     "no-void": "off",
     // disallow usage of configurable warning terms in comments: e.g. todo
@@ -131,98 +201,38 @@
     "wrap-iife": "off",
     // require or disallow Yoda conditions
     "yoda": "off",
-    // disallow trailing commas in object literals
-    "comma-dangle": "off",
-    // disallow assignment in conditional expressions
-    "no-cond-assign": "off",
-    // disallow use of console
-    "no-console": "off",
-    // disallow use of constant expressions in conditions
-    "no-constant-condition": "error",
-    // disallow control characters in regular expressions
-    "no-control-regex": "off",
-    // disallow use of debugger
-    "no-debugger": "off",
-    // disallow duplicate arguments in functions
-    "no-dupe-args": "off",
-    // disallow duplicate keys when creating object literals
-    "no-dupe-keys": "off",
-    // disallow a duplicate case label.
-    "no-duplicate-case": "off",
-    // disallow the use of empty character classes in regular expressions
-    "no-empty-character-class": "off",
-    // disallow empty statements
-    "no-empty": "off",
-    // disallow assigning to the exception in a catch block
-    "no-ex-assign": "off",
-    // disallow double-negation boolean casts in a boolean context
-    "no-extra-boolean-cast": "off",
-    // disallow unnecessary parentheses
-    "no-extra-parens": "off",
-    // disallow unnecessary semicolons
-    "no-extra-semi": "off",
-    // disallow overwriting functions written as function declarations
-    "no-func-assign": "off",
-    // disallow function or variable declarations in nested blocks
-    "no-inner-declarations": ["error", "functions"],
-    // disallow invalid regular expression strings in the RegExp constructor
-    "no-invalid-regexp": "off",
-    // disallow irregular whitespace outside of strings and comments
-    "no-irregular-whitespace": "off",
-    // disallow negation of the left operand of an in expression
-    "no-negated-in-lhs": "off",
-    // disallow the use of object properties of the global object (Math and JSON) as functions
-    "no-obj-calls": "off",
-    // disallow multiple spaces in a regular expression literal
-    "no-regex-spaces": "off",
-    // disallow sparse arrays
-    "no-sparse-arrays": "off",
-    // Avoid code that looks like two expressions but is actually one
-    "no-unexpected-multiline": "error",
-    // disallow unreachable statements after a return, throw, continue, or break statement
-    "no-unreachable": "off",
-    // disallow comparisons with the value NaN
-    "use-isnan": "off",
-    // ensure JSDoc comments are valid
-    "valid-jsdoc": "error",
-    // ensure that the results of typeof are compared against a valid string
-    "valid-typeof": "off",
-    // require braces in arrow function body
-    "arrow-body-style": ["error", "as-needed"],
-    // require parens in arrow function arguments
-    "arrow-parens": ["error", "as-needed"],
-    // require space before/after arrow function's arrow
-    "arrow-spacing": ["error", { "before": true, "after": true }],
-    // verify super() callings in constructors
-    "constructor-super": "error",
-    // enforce the spacing around the * in generator functions
-    "generator-star-spacing": "off",
-    // disallow arrow functions where they could be confused with comparisons
-    "no-confusing-arrow": ["error", {"allowParens": true}],
-    // disallow modifying variables of class declarations
-    "no-class-assign": "error",
-    // disallow modifying variables that are declared using const
-    "no-const-assign": "error",
-    // disallow duplicate name in class members
-    "no-dupe-class-members": "error",
-    // disallow to use this/super before super() calling in constructors.
-    "no-this-before-super": "error",
-    // require let or const instead of var
-    "no-var": "error",
-    // require method and property shorthand syntax for object literals
-    "object-shorthand": ["error", "always"],
-    // suggest using arrow functions as callbacks
-    "prefer-arrow-callback": "off",
-    // suggest using of const declaration for variables that are never modified after declared
-    "prefer-const": "error",
-    // suggest using Reflect methods where applicable
-    "prefer-reflect": "off",
-    // suggest using the spread operator instead of .apply()
-    "prefer-spread": "off",
-    // suggest using template literals instead of strings concatenation
-    "prefer-template": "off",
-    // disallow generator functions that do not have yield
-    "require-yield": "off",
+
+    // STRICT MODE
+    // require that all functions are run in strict mode
+    "strict": "off",
+
+    // VARIABLES
+    // enforce or disallow variable initializations at definition
+    "init-declarations": "off",
+    // disallow the catch clause parameter name being the same as a variable in the outer scope
+    "no-catch-shadow": "off",
+    // disallow deletion of variables
+    "no-delete-var": "error",
+    // disallow labels that share a name with a variable
+    "no-label-var": "off",
+    // disallow specified global variables
+    "no-restricted-globals": "off",
+    // disallow shadowing of names such as arguments
+    "no-shadow-restricted-names": "off",
+    // disallow declaration of variables already declared in the outer scope
+    "no-shadow": "off",
+    // disallow use of undefined when initializing variables
+    "no-undef-init": "off",
+    // disallow use of undeclared variables unless mentioned in a /*global */ block
+    "no-undef": "error",
+    // disallow use of undefined variable
+    "no-undefined": "off",
+    // disallow declaration of variables that are not used in the code
+    "no-unused-vars": "error",
+    // disallow use of variables before they are defined
+    "no-use-before-define": "off",
+
+    // NODE.JS AND COMMONJS
     // enforce return after a callback
     "callback-return": "off",
     // disallow require() outside of the top-level module scope
@@ -235,24 +245,28 @@
     "no-new-require": "off",
     // disallow string concatenation with __dirname and __filename
     "no-path-concat": "off",
+    // disallow the use of process.env
+    "no-process-env": "off",
     // disallow process.exit()
     "no-process-exit": "off",
     // restrict usage of specified node modules
     "no-restricted-modules": "off",
     // disallow use of synchronous methods (off by default)
     "no-sync": "off",
-    // require that all functions are run in strict mode
-    "strict": "off",
+
+    // STYLISTIC ISSUES
     // enforce spacing inside array brackets
-    "array-bracket-spacing": "off",
+    "array-bracket-spacing": ["error", "never"],
     // disallow or enforce spaces inside of single line blocks
-    "block-spacing": "off",
+    "block-spacing": ["error", "never"],
     // enforce one true brace style
     "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
     // require camel case names
     "camelcase": ["error", {"properties": "never"}],
+    // disallow trailing commas in object literals
+    "comma-dangle": ["error", "never"],
     // enforce spacing before and after comma
-    "comma-spacing": "off",
+    "comma-spacing": ["error", { "before": false, "after": true }],
     // enforce one true comma style
     "comma-style": "off",
     // require or disallow padding inside computed properties
@@ -265,6 +279,8 @@
     "func-names": "off",
     // enforces use of function declarations or expressions
     "func-style": "off",
+    // disallow specified identifiers
+    "id-blacklist": "off",
     // this option enforces minimum and maximum identifier lengths (variable names, property names etc.)
     "id-length": "off",
     // require identifiers to match the provided regular expression
@@ -275,6 +291,8 @@
     "jsx-quotes": "off",
     // enforces spacing between keys and values in object literal properties
     "key-spacing": ["error", { "beforeColon": false, "afterColon": true }],
+    // enforce spacing before and after keywords
+    "keyword-spacing": ["error", {"before": true, "after": true}],
     // disallow mixed "LF" and "CRLF" as linebreaks
     "linebreak-style": "off",
     // enforces empty lines around comments
@@ -283,18 +301,28 @@
     "max-depth": "off",
     // specify the maximum length of a line in your program
     "max-len": [2, 120],
+    // enforce a maximum number of lines per file
+    "max-lines": "off",
     // specify the maximum depth callbacks can be nested
     "max-nested-callbacks": "off",
     // limits the number of parameters that can be used in the function declaration.
     "max-params": "off",
+    // enforce a maximum number of statements allowed per line
+    "max-statements-per-line": "off",
     // specify the maximum number of statement allowed in a function
     "max-statements": "off",
+    // enforce newlines between operands of ternary expressions
+    "multiline-ternary": "off",
     // require a capital letter for constructors
     "new-cap": "error",
     // disallow the omission of parentheses when invoking a constructor with no arguments
     "new-parens": "off",
     // allow/disallow an empty newline after var statement
     "newline-after-var": "error",
+    // require an empty line before return statements
+    "newline-before-return": "off",
+    // require a newline after each call in a method chain
+    "newline-per-chained-call": "off",
     // disallow use of the Array constructor
     "no-array-constructor": "error",
     // disallow use of bitwise operators
@@ -305,6 +333,8 @@
     "no-inline-comments": "off",
     // disallow if as the only statement in an else block
     "no-lonely-if": "off",
+    // disallow mixed binary operators
+    "no-mixed-operators": "off",
     // disallow mixed spaces and tabs for indentation
     "no-mixed-spaces-and-tabs": "error",
     // disallow multiple empty lines
@@ -329,8 +359,16 @@
     "no-underscore-dangle": "off",
     // disallow the use of Boolean literals in conditional expressions
     "no-unneeded-ternary": "off",
+    // disallow whitespace before properties
+    "no-whitespace-before-property": "error",
+    // enforce consistent line breaks inside braces
+    "object-curly-newline": "off",
     // require or disallow padding inside curly braces
     "object-curly-spacing": ["error", "never"],
+    // enforce placing object properties on separate lines
+    "object-property-newline": "off",
+    // require or disallow newlines around var declarations
+    "one-var-declaration-per-line": "off",
     // allow just one var statement per function
     "one-var": "off",
     // require assignment operator shorthand where possible or prohibit it entirely
@@ -351,8 +389,6 @@
     "semi": "error",
     // sort variables within the same declaration block
     "sort-vars": "off",
-    // enforce spacing before and after keywords
-    "keyword-spacing": ["error", {"before": true, "after": true}],
     // require or disallow space before blocks
     "space-before-blocks": ["error", "always"],
     // require or disallow space before function opening parenthesis
@@ -365,30 +401,69 @@
     "space-unary-ops": "off",
     // require or disallow a space immediately following the // or /* in a comment
     "spaced-comment": "off",
+    // require or disallow Unicode byte order mark (BOM)
+    "unicode-bom": ["error", "never"],
     // require regex literals to be wrapped in parentheses
     "wrap-regex": "off",
-    // enforce or disallow variable initializations at definition
-    "init-declarations": "off",
-    // disallow the catch clause parameter name being the same as a variable in the outer scope
-    "no-catch-shadow": "off",
-    // disallow deletion of variables
-    "no-delete-var": "off",
-    // disallow labels that share a name with a variable
-    "no-label-var": "off",
-    // disallow shadowing of names such as arguments
-    "no-shadow-restricted-names": "off",
-    // disallow declaration of variables already declared in the outer scope
-    "no-shadow": "off",
-    // disallow use of undefined when initializing variables
-    "no-undef-init": "off",
-    // disallow use of undeclared variables unless mentioned in a /*global */ block
-    // FIXME - should be 0
-    "no-undef": "off",
-    // disallow use of undefined variable
-    "no-undefined": "off",
-    // disallow declaration of variables that are not used in the code
-    "no-unused-vars": "off",
-    // disallow use of variables before they are defined
-    "no-use-before-define": "off"
+
+    // ECMAScript 6
+    // require braces in arrow function body
+    "arrow-body-style": ["error", "as-needed"],
+    // require parens in arrow function arguments
+    "arrow-parens": ["error", "as-needed"],
+    // require space before/after arrow function's arrow
+    "arrow-spacing": ["error", { "before": true, "after": true }],
+    // verify super() callings in constructors
+    "constructor-super": "error",
+    // enforce the spacing around the * in generator functions
+    "generator-star-spacing": "off",
+    // disallow modifying variables of class declarations
+    "no-class-assign": "error",
+    // disallow arrow functions where they could be confused with comparisons
+    "no-confusing-arrow": ["error", {"allowParens": true}],
+    // disallow modifying variables that are declared using const
+    "no-const-assign": "error",
+    // disallow duplicate name in class members
+    "no-dupe-class-members": "error",
+    // disallow duplicate module imports
+    "no-duplicate-imports": "error",
+    // disallow symbol constructor
+    "no-new-symbol": "error",
+    // disallow specified modules when loaded by import
+    "no-restricted-imports": "off",
+    // disallow to use this/super before super() calling in constructors.
+    "no-this-before-super": "error",
+    // disallow unnecessary computed property keys in object literals
+    "no-useless-computed-key": "error",
+    // disallow unnecessary constructors
+    "no-useless-constructor": "error",
+    // disallow renaming import, export, and destructured assignments to the same name
+    "no-useless-rename": "error",
+    // require let or const instead of var
+    "no-var": "error",
+    // require method and property shorthand syntax for object literals
+    "object-shorthand": ["error", "always"],
+    // suggest using arrow functions as callbacks
+    "prefer-arrow-callback": "off",
+    // suggest using of const declaration for variables that are never modified after declared
+    "prefer-const": "error",
+    // suggest using Reflect methods where applicable
+    "prefer-reflect": "off",
+    // require rest parameters instead of arguments
+    "prefer-rest-params": "error",
+    // suggest using the spread operator instead of .apply()
+    "prefer-spread": "off",
+    // suggest using template literals instead of strings concatenation
+    "prefer-template": "off",
+    // disallow generator functions that do not have yield
+    "require-yield": "off",
+    // enforce spacing between rest and spread operators and their expressions
+    "rest-spread-spacing": ["error", "never"],
+    // enforce sorted import declarations within modules
+    "sort-imports": "error",
+    // require or disallow spacing around embedded expressions of template strings
+    "template-curly-spacing": ["error", "never"],
+    // require or disallow spacing around the * in yield* expressions
+    "yield-star-spacing":  ["error", "after"]
   }
 }

--- a/.eslintrc-es5
+++ b/.eslintrc-es5
@@ -9,377 +9,398 @@
     "ecmaVersion": 5
   },
   "rules": {
+    // POSSIBLE ERRORS
+    // disallow assignment in conditional expressions
+    "no-cond-assign": "off",
+    // disallow use of console
+    "no-console": "off",
+    // disallow use of constant expressions in conditions
+    "no-constant-condition": "error",
+    // disallow control characters in regular expressions
+    "no-control-regex": "error",
+    // disallow use of debugger
+    "no-debugger": "error",
+    // disallow duplicate arguments in functions
+    "no-dupe-args": "error",
+    // disallow duplicate keys when creating object literals
+    "no-dupe-keys": "error",
+    // disallow a duplicate case label.
+    "no-duplicate-case": "error",
+    // disallow the use of empty character classes in regular expressions
+    "no-empty-character-class": "error",
+    // disallow empty statements
+    "no-empty": "error",
+    // disallow assigning to the exception in a catch block
+    "no-ex-assign": "error",
+    // disallow double-negation boolean casts in a boolean context
+    "no-extra-boolean-cast": "off",
+    // disallow unnecessary parentheses
+    "no-extra-parens": "off",
+    // disallow unnecessary semicolons
+    "no-extra-semi": "off",
+    // disallow overwriting functions written as function declarations
+    "no-func-assign": "error",
+    // disallow function or variable declarations in nested blocks
+    "no-inner-declarations": "error",
+    // disallow invalid regular expression strings in the RegExp constructor
+    "no-invalid-regexp": "error",
+    // disallow irregular whitespace outside of strings and comments
+    "no-irregular-whitespace": "error",
+    // disallow negation of the left operand of an in expression
+    "no-negated-in-lhs": "error",
+    // disallow the use of object properties of the global object (Math and JSON) as functions
+    "no-obj-calls": "error",
+    // disallow use of Object.prototypes builtins directly
+    "no-prototype-builtins": "off",
+    // disallow multiple spaces in a regular expression literal
+    "no-regex-spaces": "error",
+    // disallow sparse arrays
+    "no-sparse-arrays": "error",
+    // Avoid code that looks like two expressions but is actually one
+    "no-unexpected-multiline": "error",
+    // disallow unreachable statements after a return, throw, continue, or break statement
+    "no-unreachable": "error",
+    // disallow control flow statements in finally blocks
+    "no-unsafe-finally": "error",
+    // disallow comparisons with the value NaN
+    "use-isnan": "error",
+    // ensure JSDoc comments are valid
+    "valid-jsdoc": "error",
+    // ensure that the results of typeof are compared against a valid string
+    "valid-typeof": "error",
+
+    // BEST PRACTIES
     // Enforces getter/setter pairs in objects
-    "accessor-pairs": 0,
+    "accessor-pairs": "off",
+    // Enforces return statements in callbacks of array methods
+    "array-callback-return": "error",
     // treat var statements as if they were block scoped
-    "block-scoped-var": 0,
+    "block-scoped-var": "off",
     // specify the maximum cyclomatic complexity allowed in a program
-    "complexity": 0,
+    "complexity": "off",
     // require return statements to either always or never specify values
-    "consistent-return": 0,
+    "consistent-return": "off",
     // specify curly brace conventions for all control statements
-    "curly": [2, "all"],
+    "curly": ["error", "all"],
     // require default case in switch statements
-    "default-case": 2,
+    "default-case": "error",
     // enforces consistent newlines before or after dots
-    "dot-location": 0,
+    "dot-location": "off",
     // encourages use of dot notation whenever possible
-    "dot-notation": 0,
+    "dot-notation": "off",
     // require the use of === and !==
-    "eqeqeq": 0,
+    "eqeqeq": "off",
     // make sure for-in loops have an if statement
-    "guard-for-in": 2,
+    "guard-for-in": "error",
     // disallow the use of alert, confirm, and prompt
-    "no-alert": 0,
+    "no-alert": "off",
     // disallow use of arguments.caller or arguments.callee
     "no-caller": "error",
     // disallow lexical declarations in case clauses
     "no-case-declarations": "error",
     // disallow division operators explicitly at beginning of regular expression
-    "no-div-regex": 0,
+    "no-div-regex": "off",
     // disallow else after a return in an if
-    "no-else-return": 0,
+    "no-else-return": "off",
+    // disallow empty functions
+    "no-empty-function": "off",
     // disallow use of empty destructuring patterns
     "no-empty-pattern": "error",
-    // disallow symbol constructor
-    "no-new-symbol": "error",
-    // disallow self assignment
-    "no-self-assign": "error",
     // disallow comparisons to null without a type-checking operator
-    "no-eq-null": 0,
+    "no-eq-null": "off",
     // disallow use of eval()
-    "no-eval": 2,
+    "no-eval": "error",
     // disallow adding to native types
-    "no-extend-native": 2,
+    "no-extend-native": "error",
     // disallow unnecessary function binding
-    "no-extra-bind": 0,
+    "no-extra-bind": "off",
+    // disallow unnecessary labels
+    "no-extra-label": "error",
     // disallow fallthrough of case statements
-    "no-fallthrough": 0,
+    "no-fallthrough": "error",
     // disallow the use of leading or trailing decimal points in numeric literals
-    "no-floating-decimal": 0,
+    "no-floating-decimal": "off",
     // disallow the type conversions with shorter notations
-    "no-implicit-coercion": 0,
+    "no-implicit-coercion": "off",
+    // disallow var and named function declarations in the global scope
+    "no-implicit-globals": "off",
     // disallow use of eval()-like methods
-    "no-implied-eval": 0,
+    "no-implied-eval": "off",
     // disallow this keywords outside of classes or class-like objects
-    "no-invalid-this": 2,
+    "no-invalid-this": "error",
     // disallow usage of __iterator__ property
-    "no-iterator": 0,
+    "no-iterator": "off",
     // disallow use of labeled statements
     "no-labels": "error",
     // disallow unnecessary nested blocks
-    "no-lone-blocks": 0,
+    "no-lone-blocks": "off",
     // disallow creation of functions within loops
-    "no-loop-func": 2,
+    "no-loop-func": "error",
     // disallow the use of magic numbers
-    "no-magic-numbers": 0,
+    "no-magic-numbers": "off",
     // disallow use of multiple spaces
-    "no-multi-spaces": 0,
+    "no-multi-spaces": "off",
     // disallow use of multiline strings
-    "no-multi-str": 2,
+    "no-multi-str": "error",
     // disallow reassignments of native objects
-    "no-native-reassign": 0,
+    "no-native-reassign": "error",
     // disallow use of new operator for Function object
-    "no-new-func": 0,
+    "no-new-func": "off",
     // disallows creating new instances of String,Number, and Boolean
-    "no-new-wrappers": 0,
+    "no-new-wrappers": "off",
     // disallow use of new operator when not part of the assignment or comparison
-    "no-new": 0,
-    // disallow use of octal escape sequences in string literals, such as
-    // var foo = "Copyright \251";
-    "no-octal-escape": 0,
+    "no-new": "off",
+    // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
+    "no-octal-escape": "off",
     // disallow use of (old style) octal literals
-    "no-octal": 0,
+    "no-octal": "error",
     // disallow reassignment of function parameters
-    "no-param-reassign": 0,
-    // disallow use of process.env
-    "no-process-env": 0,
+    "no-param-reassign": "off",
     // disallow usage of __proto__ property
-    "no-proto": 0,
+    "no-proto": "off",
     // disallow declaring the same variable more then once
-    "no-redeclare": 0,
+    "no-redeclare": "off",
     // disallow use of assignment in return statement
-    "no-return-assign": 0,
+    "no-return-assign": "off",
     // disallow use of `javascript:` urls.
-    "no-script-url": 0,
+    "no-script-url": "off",
+    // disallow assignments where both sides are exactly the same
+    "no-self-assign": "error",
     // disallow comparisons where both sides are exactly the same
-    "no-self-compare": 0,
+    "no-self-compare": "off",
     // disallow use of comma operator
-    "no-sequences": 0,
+    "no-sequences": "off",
     // restrict what can be thrown as an exception
-    "no-throw-literal": 0,
+    "no-throw-literal": "off",
+    // disallow unmodified loop conditions
+    "no-unmodified-loop-condition": "off",
     // disallow usage of expressions in statement position
-    "no-unused-expressions": 0,
+    "no-unused-expressions": "off",
+    // disallow unused labels
+    "no-unused-labels": "error",
     // disallow unnecessary .call() and .apply()
-    "no-useless-call": 0,
+    "no-useless-call": "off",
     // disallow unnecessary concatenation of literals or template literals
-    "no-useless-concat": 0,
+    "no-useless-concat": "off",
+    // disallow unnecessary escape characters
+    "no-useless-escape": "off",
     // disallow use of void operator
-    "no-void": 0,
+    "no-void": "off",
     // disallow usage of configurable warning terms in comments: e.g. todo
-    "no-warning-comments": 0,
+    "no-warning-comments": "off",
     // disallow use of the with statement
-    "no-with": 2,
+    "no-with": "error",
     // require use of the second argument for parseInt()
-    "radix": 0,
+    "radix": "off",
     // requires to declare all vars on top of their containing scope
-    "vars-on-top": 0,
+    "vars-on-top": "off",
     // require immediate function invocation to be wrapped in parentheses
-    "wrap-iife": 0,
+    "wrap-iife": "off",
     // require or disallow Yoda conditions
-    "yoda": 0,
-    // disallow trailing commas in object literals
-    "comma-dangle": 0,
-    // disallow assignment in conditional expressions
-    "no-cond-assign": 0,
-    // disallow use of console
-    "no-console": 0,
-    // disallow use of constant expressions in conditions
-    "no-constant-condition": "error",
-    // disallow control characters in regular expressions
-    "no-control-regex": 0,
-    // disallow use of debugger
-    "no-debugger": 0,
-    // disallow duplicate arguments in functions
-    "no-dupe-args": 0,
-    // disallow duplicate keys when creating object literals
-    "no-dupe-keys": 0,
-    // disallow a duplicate case label.
-    "no-duplicate-case": 0,
-    // disallow the use of empty character classes in regular expressions
-    "no-empty-character-class": 0,
-    // disallow empty statements
-    "no-empty": 0,
-    // disallow assigning to the exception in a catch block
-    "no-ex-assign": 0,
-    // disallow double-negation boolean casts in a boolean context
-    "no-extra-boolean-cast": 0,
-    // disallow unnecessary parentheses
-    "no-extra-parens": 0,
-    // disallow unnecessary semicolons
-    "no-extra-semi": 0,
-    // disallow overwriting functions written as function declarations
-    "no-func-assign": 0,
-    // disallow function or variable declarations in nested blocks
-    "no-inner-declarations": [2, "functions"],
-    // disallow invalid regular expression strings in the RegExp constructor
-    "no-invalid-regexp": 0,
-    // disallow irregular whitespace outside of strings and comments
-    "no-irregular-whitespace": 0,
-    // disallow negation of the left operand of an in expression
-    "no-negated-in-lhs": 0,
-    // disallow the use of object properties of the global object (Math and JSON) as functions
-    "no-obj-calls": 0,
-    // disallow multiple spaces in a regular expression literal
-    "no-regex-spaces": 0,
-    // disallow sparse arrays
-    "no-sparse-arrays": 0,
-    // Avoid code that looks like two expressions but is actually one
-    "no-unexpected-multiline": "error",
-    // disallow unreachable statements after a return, throw, continue, or break statement
-    "no-unreachable": 0,
-    // disallow comparisons with the value NaN
-    "use-isnan": 0,
-    // ensure JSDoc comments are valid
-    "valid-jsdoc": 2,
-    // ensure that the results of typeof are compared against a valid string
-    "valid-typeof": 0,
-    // require braces in arrow function body
-    "arrow-body-style": 0,
-    // require parens in arrow function arguments
-    "arrow-parens": 0,
-    // require space before/after arrow function's arrow
-    "arrow-spacing": [2, { "before": true, "after": true }],
-    // verify super() callings in constructors
-    "constructor-super": "error",
-    // enforce the spacing around the * in generator functions
-    "generator-star-spacing": 0,
-    // disallow arrow functions where they could be confused with comparisons
-    "no-confusing-arrow": "error",
-    // disallow modifying variables of class declarations
-    "no-class-assign": "error",
-    // disallow modifying variables that are declared using const
-    "no-const-assign": 2,
-    // disallow to use this/super before super() calling in constructors.
-    "no-this-before-super": "error",
-    // suggest using arrow functions as callbacks
-    "prefer-arrow-callback": 0,
-    // suggest using of const declaration for variables that are never modified after declared
-    "prefer-const": 2,
-    // suggest using Reflect methods where applicable
-    "prefer-reflect": 0,
-    // suggest using the spread operator instead of .apply()
-    "prefer-spread": 0,
-    // suggest using template literals instead of strings concatenation
-    "prefer-template": 0,
-    // disallow generator functions that do not have yield
-    "require-yield": 0,
-    // enforce return after a callback
-    "callback-return": 0,
-    // disallow require() outside of the top-level module scope
-    "global-require": 0,
-    // enforces error handling in callbacks (node environment)
-    "handle-callback-err": 0,
-    // disallow mixing regular variable and require declarations
-    "no-mixed-requires": 0,
-    // disallow use of new operator with the require function
-    "no-new-require": 0,
-    // disallow string concatenation with __dirname and __filename
-    "no-path-concat": 0,
-    // disallow process.exit()
-    "no-process-exit": 0,
-    // restrict usage of specified node modules
-    "no-restricted-modules": 0,
-    // disallow use of synchronous methods (off by default)
-    "no-sync": 0,
+    "yoda": "off",
+
+    // STRICT MODE
     // require that all functions are run in strict mode
-    "strict": 0,
+    "strict": "off",
+
+    // VARIABLES
+    // enforce or disallow variable initializations at definition
+    "init-declarations": "off",
+    // disallow the catch clause parameter name being the same as a variable in the outer scope
+    "no-catch-shadow": "off",
+    // disallow deletion of variables
+    "no-delete-var": "error",
+    // disallow labels that share a name with a variable
+    "no-label-var": "off",
+    // disallow specified global variables
+    "no-restricted-globals": "off",
+    // disallow shadowing of names such as arguments
+    "no-shadow-restricted-names": "off",
+    // disallow declaration of variables already declared in the outer scope
+    "no-shadow": "off",
+    // disallow use of undefined when initializing variables
+    "no-undef-init": "off",
+    // disallow use of undeclared variables unless mentioned in a /*global */ block
+    "no-undef": "off",
+    // disallow use of undefined variable
+    "no-undefined": "off",
+    // disallow declaration of variables that are not used in the code
+    "no-unused-vars": "off",
+    // disallow use of variables before they are defined
+    "no-use-before-define": "off",
+
+    // NODE.JS AND COMMONJS
+    // enforce return after a callback
+    "callback-return": "off",
+    // disallow require() outside of the top-level module scope
+    "global-require": "off",
+    // enforces error handling in callbacks (node environment)
+    "handle-callback-err": "off",
+    // disallow mixing regular variable and require declarations
+    "no-mixed-requires": "off",
+    // disallow use of new operator with the require function
+    "no-new-require": "off",
+    // disallow string concatenation with __dirname and __filename
+    "no-path-concat": "off",
+    // disallow the use of process.env
+    "no-process-env": "off",
+    // disallow process.exit()
+    "no-process-exit": "off",
+    // restrict usage of specified node modules
+    "no-restricted-modules": "off",
+    // disallow use of synchronous methods (off by default)
+    "no-sync": "off",
+
+    // STYLISTIC ISSUES
     // enforce spacing inside array brackets
-    "array-bracket-spacing": 0,
+    "array-bracket-spacing": "off",
     // disallow or enforce spaces inside of single line blocks
-    "block-spacing": 0,
+    "block-spacing": ["error", "never"],
     // enforce one true brace style
-    "brace-style": [2, "1tbs", { "allowSingleLine": true }],
+    "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
     // require camel case names
-    "camelcase": [2, {"properties": "never"}],
+    "camelcase": ["error", {"properties": "never"}],
+    // disallow trailing commas in object literals
+    "comma-dangle": "off",
     // enforce spacing before and after comma
-    "comma-spacing": 0,
+    "comma-spacing": "off",
     // enforce one true comma style
-    "comma-style": 0,
+    "comma-style": "off",
     // require or disallow padding inside computed properties
-    "computed-property-spacing": 0,
+    "computed-property-spacing": "off",
     // enforces consistent naming when capturing the current execution context
-    "consistent-this": 0,
+    "consistent-this": "off",
     // enforce newline at the end of file, with no multiple empty lines
-    "eol-last": 0,
+    "eol-last": "off",
     // require function expressions to have a name
-    "func-names": 0,
+    "func-names": "off",
     // enforces use of function declarations or expressions
-    "func-style": 0,
+    "func-style": "off",
+    // disallow specified identifiers
+    "id-blacklist": "off",
     // this option enforces minimum and maximum identifier lengths (variable names, property names etc.)
-    "id-length": 0,
+    "id-length": "off",
     // require identifiers to match the provided regular expression
-    "id-match": 0,
+    "id-match": "off",
     // this option sets a specific tab width for your code
-    "indent": [2, 2, {"SwitchCase": 1}],
+    "indent": ["error", 2, {"SwitchCase": 1}],
     // specify whether double or single quotes should be used in JSX attributes
-    "jsx-quotes": 0,
+    "jsx-quotes": "off",
     // enforces spacing between keys and values in object literal properties
-    "key-spacing": [2, { "beforeColon": false, "afterColon": true }],
-    // disallow mixed "LF" and "CRLF" as linebreaks
-    "linebreak-style": 0,
-    // enforces empty lines around comments
-    "lines-around-comment": 0,
-    // specify the maximum depth that blocks can be nested
-    "max-depth": 0,
-    // specify the maximum length of a line in your program
-    "max-len": [2, 120],
-    // specify the maximum depth callbacks can be nested
-    "max-nested-callbacks": 0,
-    // limits the number of parameters that can be used in the function declaration.
-    "max-params": 0,
-    // specify the maximum number of statement allowed in a function
-    "max-statements": 0,
-    // require a capital letter for constructors
-    "new-cap": 2,
-    // disallow the omission of parentheses when invoking a constructor with no arguments
-    "new-parens": 0,
-    // allow/disallow an empty newline after var statement
-    "newline-after-var": 2,
-    // disallow use of the Array constructor
-    "no-array-constructor": 2,
-    // disallow use of bitwise operators
-    "no-bitwise": 0,
-    // disallow use of the continue statement
-    "no-continue": 0,
-    // disallow comments inline after code
-    "no-inline-comments": 0,
-    // disallow if as the only statement in an else block
-    "no-lonely-if": 0,
-    // disallow mixed spaces and tabs for indentation
-    "no-mixed-spaces-and-tabs": 2,
-    // disallow multiple empty lines
-    "no-multiple-empty-lines": 0,
-    // disallow negated conditions
-    "no-negated-condition": 0,
-    // disallow nested ternary expressions
-    "no-nested-ternary": 0,
-    // disallow use of the Object constructor
-    "no-new-object": 2,
-    // disallow use of unary operators, ++ and --
-    "no-plusplus": 0,
-    // disallow use of certain syntax in code
-    "no-restricted-syntax": 0,
-    // disallow space between function identifier and application
-    "no-spaced-func": 2,
-    // disallow the use of ternary operators
-    "no-ternary": 0,
-    // disallow trailing whitespace at the end of lines
-    "no-trailing-spaces": 2,
-    // disallow dangling underscores in identifiers
-    "no-underscore-dangle": 0,
-    // disallow the use of Boolean literals in conditional expressions
-    "no-unneeded-ternary": 0,
-    // require or disallow padding inside curly braces
-    "object-curly-spacing": [2, "never"],
-    // allow just one var statement per function
-    "one-var": 0,
-    // require assignment operator shorthand where possible or prohibit it entirely
-    "operator-assignment": 0,
-    // enforce operators to be placed before or after line breaks
-    "operator-linebreak": [2, "after"],
-    // enforce padding within blocks
-    "padded-blocks": 0,
-    // require quotes around object literal property names
-    "quote-props": 0,
-    // specify whether double or single quotes should be used
-    "quotes": [2, "single"],
-    // Require JSDoc comment
-    "require-jsdoc": 0,
-    // enforce spacing before and after semicolons
-    "semi-spacing": 0,
-    // require or disallow use of semicolons instead of ASI
-    "semi": 2,
-    // sort variables within the same declaration block
-    "sort-vars": 0,
+    "key-spacing": ["error", { "beforeColon": false, "afterColon": true }],
     // enforce spacing before and after keywords
     "keyword-spacing": ["error", {"before": true, "after": true}],
+    // disallow mixed "LF" and "CRLF" as linebreaks
+    "linebreak-style": "off",
+    // enforces empty lines around comments
+    "lines-around-comment": "off",
+    // specify the maximum depth that blocks can be nested
+    "max-depth": "off",
+    // specify the maximum length of a line in your program
+    "max-len": ["error", 120],
+    // enforce a maximum number of lines per file
+    "max-lines": "off",
+    // specify the maximum depth callbacks can be nested
+    "max-nested-callbacks": "off",
+    // limits the number of parameters that can be used in the function declaration.
+    "max-params": "off",
+    // enforce a maximum number of statements allowed per line
+    "max-statements-per-line": "off",
+    // specify the maximum number of statement allowed in a function
+    "max-statements": "off",
+    // enforce newlines between operands of ternary expressions
+    "multiline-ternary": "off",
+    // require a capital letter for constructors
+    "new-cap": "error",
+    // disallow the omission of parentheses when invoking a constructor with no arguments
+    "new-parens": "off",
+    // allow/disallow an empty newline after var statement
+    "newline-after-var": "error",
+    // require an empty line before return statements
+    "newline-before-return": "off",
+    // require a newline after each call in a method chain
+    "newline-per-chained-call": "off",
+    // disallow use of the Array constructor
+    "no-array-constructor": "error",
+    // disallow use of bitwise operators
+    "no-bitwise": "off",
+    // disallow use of the continue statement
+    "no-continue": "off",
+    // disallow comments inline after code
+    "no-inline-comments": "off",
+    // disallow if as the only statement in an else block
+    "no-lonely-if": "off",
+    // disallow mixed binary operators
+    "no-mixed-operators": "off",
+    // disallow mixed spaces and tabs for indentation
+    "no-mixed-spaces-and-tabs": "error",
+    // disallow multiple empty lines
+    "no-multiple-empty-lines": "off",
+    // disallow negated conditions
+    "no-negated-condition": "off",
+    // disallow nested ternary expressions
+    "no-nested-ternary": "off",
+    // disallow use of the Object constructor
+    "no-new-object": "error",
+    // disallow use of unary operators, ++ and --
+    "no-plusplus": "off",
+    // disallow use of certain syntax in code
+    "no-restricted-syntax": "off",
+    // disallow space between function identifier and application
+    "no-spaced-func": "error",
+    // disallow the use of ternary operators
+    "no-ternary": "off",
+    // disallow trailing whitespace at the end of lines
+    "no-trailing-spaces": "error",
+    // disallow dangling underscores in identifiers
+    "no-underscore-dangle": "off",
+    // disallow the use of Boolean literals in conditional expressions
+    "no-unneeded-ternary": "off",
+    // disallow whitespace before properties
+    "no-whitespace-before-property": "error",
+    // enforce consistent line breaks inside braces
+    "object-curly-newline": "off",
+    // require or disallow padding inside curly braces
+    "object-curly-spacing": ["error", "never"],
+    // enforce placing object properties on separate lines
+    "object-property-newline": "off",
+    // require or disallow newlines around var declarations
+    "one-var-declaration-per-line": "off",
+    // allow just one var statement per function
+    "one-var": "off",
+    // require assignment operator shorthand where possible or prohibit it entirely
+    "operator-assignment": "off",
+    // enforce operators to be placed before or after line breaks
+    "operator-linebreak": ["error", "after"],
+    // enforce padding within blocks
+    "padded-blocks": "off",
+    // require quotes around object literal property names
+    "quote-props": "off",
+    // specify whether double or single quotes should be used
+    "quotes": ["error", "single"],
+    // Require JSDoc comment
+    "require-jsdoc": "off",
+    // enforce spacing before and after semicolons
+    "semi-spacing": "off",
+    // require or disallow use of semicolons instead of ASI
+    "semi": "error",
+    // sort variables within the same declaration block
+    "sort-vars": "off",
     // require or disallow space before blocks
-    "space-before-blocks": [2, "always"],
+    "space-before-blocks": ["error", "always"],
     // require or disallow space before function opening parenthesis
-    "space-before-function-paren": [2, "never"],
+    "space-before-function-paren": ["error", "never"],
     // require or disallow spaces inside parentheses
-    "space-in-parens": [2, "never"],
+    "space-in-parens": ["error", "never"],
     // require spaces around operators
-    "space-infix-ops": 2,
+    "space-infix-ops": "error",
     // Require or disallow spaces before/after unary operators
-    "space-unary-ops": 0,
+    "space-unary-ops": "off",
     // require or disallow a space immediately following the // or /* in a comment
-    "spaced-comment": 0,
+    "spaced-comment": "off",
+    // require or disallow Unicode byte order mark (BOM)
+    "unicode-bom": ["error", "never"],
     // require regex literals to be wrapped in parentheses
-    "wrap-regex": 0,
-    // enforce or disallow variable initializations at definition
-    "init-declarations": 0,
-    // disallow the catch clause parameter name being the same as a variable in the outer scope
-    "no-catch-shadow": 0,
-    // disallow deletion of variables
-    "no-delete-var": 0,
-    // disallow labels that share a name with a variable
-    "no-label-var": 0,
-    // disallow shadowing of names such as arguments
-    "no-shadow-restricted-names": 0,
-    // disallow declaration of variables already declared in the outer scope
-    "no-shadow": 0,
-    // disallow use of undefined when initializing variables
-    "no-undef-init": 0,
-    // disallow use of undeclared variables unless mentioned in a /*global */ block
-    // FIXME - should be 0
-    "no-undef": 0,
-    // disallow use of undefined variable
-    "no-undefined": 0,
-    // disallow declaration of variables that are not used in the code
-    "no-unused-vars": 0,
-    // disallow use of variables before they are defined
-    "no-use-before-define": 0
+    "wrap-regex": "off",
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-tools-configs",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "Brainly Front-End tools configuration files",
   "author": "Brainly",
   "private": true,


### PR DESCRIPTION
I have updated all rules to match order and groups on page:
http://eslint.org/docs/rules/

All recommended rules are enabled. I have enabled some additional rules as well (mostly from es6 group and best practices)

There is over 100 errors in symfony es6 files right now.
Most of them referes to:
no-undef - http://eslint.org/docs/rules/no-undef
sort-imports - http://eslint.org/docs/rules/sort-imports
no-unused-vars - disallow unused variables

WDYT about this setup?