### PR TITLE
Update no-unused-vars

### DIFF
--- a/eslint/main.js
+++ b/eslint/main.js
@@ -258,7 +258,7 @@ module.exports = {
     // disallow use of undefined variable
     'no-undefined': 'off',
     // disallow declaration of variables that are not used in the code
-    'no-unused-vars': 'error',
+    'no-unused-vars': ["error", { "ignoreRestSiblings": true }],
     // disallow use of variables before they are defined
     'no-use-before-define': 'off',
 


### PR DESCRIPTION
Allows this:
```
// 'type' is ignored because it has a rest property sibling.
var { type, ...coords } = data;
```  