### PR TITLE
Update JSX eslint rules

### DIFF
--- a/eslint/main.js
+++ b/eslint/main.js
@@ -54,7 +54,10 @@ module.exports = {
     // disallow double-negation boolean casts in a boolean context
     'no-extra-boolean-cast': 'error',
     // disallow unnecessary parentheses
-    'no-extra-parens': ['error', 'all', {'nestedBinaryExpressions': false}],
+    'no-extra-parens': ['error', 'all', {
+      'nestedBinaryExpressions': false,
+      'ignoreJSX': 'multi-line'
+    }],
     // disallow unnecessary semicolons
     'no-extra-semi': 'error',
     // disallow overwriting functions written as function declarations
@@ -258,7 +261,7 @@ module.exports = {
     // disallow use of undefined variable
     'no-undefined': 'off',
     // disallow declaration of variables that are not used in the code
-    'no-unused-vars': ["error", { "ignoreRestSiblings": true }],
+    'no-unused-vars': ['error', {'ignoreRestSiblings': true}],
     // disallow use of variables before they are defined
     'no-use-before-define': 'off',
 
@@ -448,9 +451,9 @@ module.exports = {
     'space-before-blocks': ['error', 'always'],
     // require or disallow space before function opening parenthesis
     'space-before-function-paren': ['error', {
-      "anonymous": "never",
-      "named": "never",
-      "asyncArrow": "always"
+      'anonymous': 'never',
+      'named': 'never',
+      'asyncArrow': 'always'
     }],
     // require or disallow spaces inside parentheses
     'space-in-parens': ['error', 'never'],

--- a/eslint/react.js
+++ b/eslint/react.js
@@ -26,6 +26,8 @@ module.exports = {
     'react/forbid-prop-types': 'off',
     // Forbid foreign propTypes
     'react/forbid-foreign-prop-types': 'error',
+    // Prevent using this.state inside this.setState
+    'react/no-access-state-in-setstate': 'error',
     // Prevent using Array index in key props
     'react/no-array-index-key': 'off',
     // Prevent passing children as props
@@ -39,7 +41,7 @@ module.exports = {
     // Prevent usage of setState in componentDidMount
     'react/no-did-mount-set-state': 'error',
     // Prevent usage of setState in componentDidUpdate
-    'react/no-did-update-set-state': 'off',
+    'react/no-did-update-set-state': 'error',
     // Prevent direct mutation of this.state
     'react/no-direct-mutation-state': 'error',
     // Prevent usage of findDOMNode
@@ -81,7 +83,7 @@ module.exports = {
     // Enforce ES5 or ES6 class for returning value in render function
     'react/require-render-return': 'error',
     // Prevent extra closing tags for components without children (fixable)
-    'react/self-closing-comp': 'off',
+    'react/self-closing-comp': 'error',
     // Enforce component methods order
     'react/sort-comp': 'error',
     // Enforce propTypes declarations alphabetical sorting
@@ -95,7 +97,7 @@ module.exports = {
     // Enforce boolean attributes notation in JSX (fixable)
     'react/jsx-boolean-value': 'error',
     // Validate closing bracket location in JSX (fixable)
-    'react/jsx-closing-bracket-location': 'off',
+    'react/jsx-closing-bracket-location': ['error', 'line-aligned'],
     // Validate closing tag location in JSX
     'react/jsx-closing-tag-location': 'error',
     // Enforce or disallow spaces inside of curly braces in JSX attributes (fixable)
@@ -105,17 +107,20 @@ module.exports = {
     // Restrict file extensions that may contain JSX
     'react/jsx-filename-extension': 'error',
     // Enforce position of the first prop in JSX
-    'react/jsx-first-prop-new-line': 'off',
+    'react/jsx-first-prop-new-line': ['error', 'multiline'],
     // Enforce event handler naming conventions in JSX
     'react/jsx-handler-names': 'off',
     // Validate JSX indentation
     'react/jsx-indent': ['error', 2],
     // Validate props indentation in JSX (fixable)
-    'react/jsx-indent-props': 'off',
+    'react/jsx-indent-props': ['error', 2],
     // Validate JSX has key prop when in array or iterator
     'react/jsx-key': 'error',
     // Limit maximum of props on a single line in JSX
-    'react/jsx-max-props-per-line': 'off',
+    'react/jsx-max-props-per-line': ['error', {
+      'maximum': 1,
+      'when': 'multiline'
+    }],
     // Prevent usage of .bind() and arrow functions in JSX props
     'react/jsx-no-bind': 'error',
     // Prevent comments from being inserted as text nodes
@@ -139,7 +144,15 @@ module.exports = {
     // Prevent variables used in JSX to be incorrectly marked as unused
     'react/jsx-uses-vars': 'error',
     // Prevent missing parentheses around multilines JSX (fixable)
-    'react/jsx-wrap-multilines': 'off',
+    'react/jsx-wrap-multilines': ['error', {
+      'declaration': 'parens-new-line',
+      'assignment': 'parens-new-line',
+      'return': 'parens-new-line',
+      'arrow': 'parens-new-line',
+      'condition': 'ignore',
+      'logical': 'ignore',
+      'prop': 'ignore'
+    }],
     // This rule enforces the consistent use of either double or single quotes in JSX attributes
     'jsx-quotes': ['error', 'prefer-double']
   }

--- a/eslint/react.js
+++ b/eslint/react.js
@@ -97,7 +97,7 @@ module.exports = {
     // Enforce boolean attributes notation in JSX (fixable)
     'react/jsx-boolean-value': 'error',
     // Validate closing bracket location in JSX (fixable)
-    'react/jsx-closing-bracket-location': ['error', 'line-aligned'],
+    'react/jsx-closing-bracket-location': 'error',
     // Validate closing tag location in JSX
     'react/jsx-closing-tag-location': 'error',
     // Enforce or disallow spaces inside of curly braces in JSX attributes (fixable)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-tools-configs",
-  "version": "16.1.4",
+  "version": "16.1.5",
   "description": "Brainly Front-End tools configuration files",
   "author": "Brainly",
   "private": true,


### PR DESCRIPTION
> **tl;dr** JSX styling update, look through the code samples below (just 6 of them).

# Styling

I improved some styling rules to make the code more readable and easier to modify. 

**All of these are auto-fixable**.

The 3 most noticeable changes are described below.

## Closing bracket location
Close tags in a new line after the last prop, indented to the same level as the tag's beginning.

#### Why?
It makes it easy to see where tags start and end, also much easier to spot where the tag's children section begin.
Also easy to add remove props - you'll never delete this closing `/>` by accident again.
```jsx
// 👎👎👎
<Mati
  howLong="forLife">
  {/* Mati's children which are hard to find. */}
</Mati>
```
```jsx
// 👍👍👍
<Mati
  howLong="forLife"
>
  {/* Oh look - some children! Easy to spot because of the indent. */}
</Mati>
```
Enforced by [`jsx-closing-bracket-location`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md).

## Props per line
Keep the component single-line or spread the components one per line. Nothing in between.
#### Why?
Easier to read, easier to refactor.
```jsx
// 👎👎👎
<Something how="many props"
  do={you} see 
  in={this.element}
/>
```
```jsx
// 👍👍👍
<Something
  how="many props"
  do={you}
  see 
  in={this.element}
/>

// But this is still good!
<SomethingShorter with={some} short="props" />
```
Enforced by: [`jsx-first-prop-new-line`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md) + [`jsx-max-props-per-line`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md) with these configurations: [[1]](https://github.com/brainly/frontend-tools-configs/pull/56/files#diff-088079626465e2a903bb7f1c51be2486R110) [[2]](https://github.com/brainly/frontend-tools-configs/pull/56/files#diff-088079626465e2a903bb7f1c51be2486R120).

## Wrap JSX in parens
Wrap JSX in parentheses and put it in new lines. Makes a clear distinction where pure JS ends and JSX starts.
#### Why?
This one I didn't like myself but learned that it's useful: it makes some most basic JSX manipulations - inserting / removing / reordering elements - much easier.

```jsx
// 👎👎👎
return <Mati
  howLong="forLife"
/>;
```
```jsx
// 👍👍👍
return (
  <Mati
    howLong="forLife"
  />
);

// Still OK with a single-line element!
return <Mati howLong="forLife" />;
```
Enforced by: [`jsx-wrap-multilines`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md) with [this configuration](https://github.com/brainly/frontend-tools-configs/pull/56/files#diff-088079626465e2a903bb7f1c51be2486R147).