### PR TITLE
Enforce newer plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-tools-configs",
-  "version": "16.1.5",
+  "version": "16.1.6",
   "description": "Brainly Front-End tools configuration files",
   "author": "Brainly",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "eslint": "^4.5.0",
     "eslint-plugin-babel": "^4.1.2",
-    "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-react": "^7.3.0"
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-react": "^7.5.1"
   }
 }


### PR DESCRIPTION
They were upgraded here in yarn.lock, but not enforced by package.json