### PR TITLE
Update closing-bracket-location setting to line-aligned

### DIFF
--- a/eslint/react.js
+++ b/eslint/react.js
@@ -97,7 +97,7 @@ module.exports = {
     // Enforce boolean attributes notation in JSX (fixable)
     'react/jsx-boolean-value': 'error',
     // Validate closing bracket location in JSX (fixable)
-    'react/jsx-closing-bracket-location': 'error',
+    'react/jsx-closing-bracket-location': ['error', 'line-aligned'],
     // Validate closing tag location in JSX
     'react/jsx-closing-tag-location': 'error',
     // Enforce or disallow spaces inside of curly braces in JSX attributes (fixable)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-tools-configs",
-  "version": "16.1.6",
+  "version": "16.1.7",
   "description": "Brainly Front-End tools configuration files",
   "author": "Brainly",
   "private": true,


### PR DESCRIPTION
Default setting conflicts with `jsx-indent`