### PR TITLE
Disable no-duplicate-imports

### DIFF
--- a/eslint/main.js
+++ b/eslint/main.js
@@ -492,7 +492,8 @@ module.exports = {
     // disallow duplicate name in class members
     'no-dupe-class-members': 'error',
     // disallow duplicate module imports
-    'no-duplicate-imports': 'error',
+    // we're using the smarter `import/no-duplicates` rule, this one does not handle type imports
+    'no-duplicate-imports': 'off',
     // disallow symbol constructor
     'no-new-symbol': 'error',
     // disallow specified modules when loaded by import

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-tools-configs",
-  "version": "16.2.1",
+  "version": "16.2.2",
   "description": "Brainly Front-End tools configuration files",
   "author": "Brainly",
   "private": true,


### PR DESCRIPTION
We're already using the smarter `import/no-duplicates` rule, this one does not handle type imports.