### PR TITLE
Updated setting for no-extra-parens

### DIFF
--- a/eslint/main.js
+++ b/eslint/main.js
@@ -56,7 +56,8 @@ module.exports = {
     // disallow unnecessary parentheses
     'no-extra-parens': ['error', 'all', {
       'nestedBinaryExpressions': false,
-      'ignoreJSX': 'multi-line'
+      'ignoreJSX': 'multi-line',
+      'enforceForArrowConditionals': true
     }],
     // disallow unnecessary semicolons
     'no-extra-semi': 'error',

--- a/eslint/main.js
+++ b/eslint/main.js
@@ -57,7 +57,7 @@ module.exports = {
     'no-extra-parens': ['error', 'all', {
       'nestedBinaryExpressions': false,
       'ignoreJSX': 'multi-line',
-      'enforceForArrowConditionals': true
+      'enforceForArrowConditionals': false
     }],
     // disallow unnecessary semicolons
     'no-extra-semi': 'error',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-tools-configs",
-  "version": "16.2.3",
+  "version": "16.2.4",
   "description": "Brainly Front-End tools configuration files",
   "author": "Brainly",
   "private": true,


### PR DESCRIPTION
```js
export const togglePlay = autoPlay => prevState => {
  return prevState.playing ?
    stopPlay(prevState) :
    startPlay(autoPlay)(prevState);
};
```

This gives the following error:
`error  Unexpected block statement surrounding arrow body  arrow-body-style`

This should work with `enforceForArrowConditionals` set to `false` for `no-extra-parens` rule:
```js
export const togglePlay = autoPlay => prevState => (
  prevState.playing ?
    stopPlay(prevState) :
    startPlay(autoPlay)(prevState);
);