### PR TITLE
Add 'ignorePackages' as default behaviour

### DIFF
--- a/eslint/main.js
+++ b/eslint/main.js
@@ -544,7 +544,7 @@ module.exports = {
     // Reports if a resolved path is imported more than once.
     'import/no-duplicates': 'error',
     // Ensure consistent use of file extension within the import path
-    'import/extensions': ['error', {
+    'import/extensions': ['error', 'ignorePackages', {
       js: 'never',
       jsx: 'never'
     }],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-tools-configs",
-  "version": "16.2.4",
+  "version": "16.2.6",
   "description": "Brainly Front-End tools configuration files",
   "author": "Brainly",
   "private": true,


### PR DESCRIPTION
Current setting was reporting errors on imoprting from 'socket.io' or 'Something.spec'
 